### PR TITLE
Add status tracking for notes

### DIFF
--- a/add_note.php
+++ b/add_note.php
@@ -14,7 +14,7 @@ if ($content === '') {
     exit;
 }
 
-$stmt = $pdo->prepare('INSERT INTO notes (user_id, content) VALUES (?, ?)');
+$stmt = $pdo->prepare('INSERT INTO notes (user_id, content, status) VALUES (?, ?, "Pending")');
 $stmt->execute([$_SESSION['user_id'], $content]);
 
 echo json_encode(['success' => true]);

--- a/fetch_notes.php
+++ b/fetch_notes.php
@@ -9,9 +9,8 @@ if (!isset($_SESSION['user_id'])) {
 require 'db.php';
 header('Content-Type: application/json');
 
-$stmt = $pdo->query('SELECT notes.content, notes.created_at, users.username FROM notes JOIN users ON notes.user_id = users.id ORDER BY notes.created_at DESC');
+$stmt = $pdo->query("SELECT notes.id, notes.content, notes.created_at, notes.status, notes.updated_at, u1.username AS username, u2.username AS updated_by FROM notes JOIN users u1 ON notes.user_id = u1.id LEFT JOIN users u2 ON notes.updated_by = u2.id ORDER BY notes.created_at DESC");
 $notes = $stmt->fetchAll();
 
 echo json_encode($notes);
 ?>
-

--- a/schema.sql
+++ b/schema.sql
@@ -19,7 +19,11 @@ CREATE TABLE notes (
   user_id INT NOT NULL,
   content TEXT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users(id)
+  status ENUM('Pending','Completed') DEFAULT 'Pending',
+  updated_by INT DEFAULT NULL,
+  updated_at DATETIME DEFAULT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (updated_by) REFERENCES users(id)
 );
 
 INSERT INTO roles (name) VALUES ('administrador'), ('recepcionista');

--- a/script.js
+++ b/script.js
@@ -107,14 +107,35 @@ async function renderNotes() {
 
     notes.forEach(note => {
         const noteDiv = document.createElement('div');
-        noteDiv.className = 'note';
+        noteDiv.className = 'note ' + (note.status === 'Completed' ? 'completed' : 'pending');
+
+        const updatedInfo = note.updated_by ? `<div class="note-meta">🔄 ${note.updated_by} | 🕒 ${note.updated_at}</div>` : '';
 
         noteDiv.innerHTML = `
       <div class="note-meta">👤 ${note.username} | 🕒 ${note.created_at}</div>
       <div>${note.content}</div>
+      <div class="note-meta">Estado: ${note.status}</div>
+      <select onchange="changeStatus(${note.id}, this.value)">
+        <option value="Pending" ${note.status === 'Pending' ? 'selected' : ''}>Pending</option>
+        <option value="Completed" ${note.status === 'Completed' ? 'selected' : ''}>Completed</option>
+      </select>
+      ${updatedInfo}
     `;
 
         notesList.appendChild(noteDiv);
     });
+}
+
+async function changeStatus(id, status) {
+    const fd = new FormData();
+    fd.append('id', id);
+    fd.append('status', status);
+    const res = await fetch('update_status.php', { method: 'POST', body: fd });
+    const data = await res.json();
+    if (data.success) {
+        renderNotes();
+    } else {
+        alert('⚠️ ' + data.message);
+    }
 }
 

--- a/style.css
+++ b/style.css
@@ -73,6 +73,18 @@ button:hover {
     word-wrap: break-word;
 }
 
+.note.pending {
+    background-color: #fff9c4;
+}
+
+.note.completed {
+    background-color: #dcedc8;
+}
+
+.note select {
+    margin-top: 8px;
+}
+
 .note-meta {
     font-size: 13px;
     color: #555;

--- a/update_status.php
+++ b/update_status.php
@@ -1,0 +1,23 @@
+<?php
+session_start();
+require 'db.php';
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    echo json_encode(['success' => false, 'message' => 'No autenticado']);
+    exit;
+}
+
+$noteId = intval($_POST['id'] ?? 0);
+$status = $_POST['status'] ?? '';
+
+if (!$noteId || !in_array($status, ['Pending', 'Completed'])) {
+    echo json_encode(['success' => false, 'message' => 'Datos inválidos']);
+    exit;
+}
+
+$stmt = $pdo->prepare('UPDATE notes SET status = ?, updated_by = ?, updated_at = NOW() WHERE id = ?');
+$stmt->execute([$status, $_SESSION['user_id'], $noteId]);
+
+echo json_encode(['success' => true]);
+?>


### PR DESCRIPTION
## Summary
- track note status with `Pending` or `Completed` values and store who updated it and when
- allow updating status via new `update_status.php` endpoint and show status info in the UI
- color-code notes based on status

## Testing
- `php -l add_note.php`
- `php -l fetch_notes.php`
- `php -l update_status.php`
- `php -l index.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68950007bc9883259678b9cc6f981f4a