### PR TITLE
Add pastel status backgrounds for notes

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,11 +74,11 @@ button:hover {
 }
 
 .note.pending {
-    background-color: #fff9c4;
+    background-color: #fffde7; /* light pastel yellow */
 }
 
 .note.completed {
-    background-color: #dcedc8;
+    background-color: #e8f5e9; /* light pastel green */
 }
 
 .note select {


### PR DESCRIPTION
## Summary
- Highlight pending notes with light pastel yellow
- Highlight completed notes with light pastel green

## Testing
- `npx --yes stylelint style.css` (fails: 403 Forbidden)
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68950701c5a48325a7c300867ed038eb