### PR TITLE
Implement role-based access control

### DIFF
--- a/add_note.php
+++ b/add_note.php
@@ -8,6 +8,11 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+if (($_SESSION['role_id'] ?? 0) !== 1) {
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+
 $content = trim($_POST['content'] ?? '');
 if ($content === '') {
     echo json_encode(['success' => false, 'message' => 'Contenido vacío']);

--- a/index.php
+++ b/index.php
@@ -20,6 +20,7 @@ require 'db.php';
 // }
 
 $loggedUser = $_SESSION['username'] ?? null;
+$loggedRole = $_SESSION['role_id'] ?? null;
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -50,9 +51,11 @@ $loggedUser = $_SESSION['username'] ?? null;
         </div>
 
         <div id="noteSection" <?php if (!$loggedUser) echo 'style="display:none;"'; ?>>
-            <p>👤 Sesión iniciada como <span id="userDisplay"><?php echo htmlspecialchars($loggedUser ?? '', ENT_QUOTES, 'UTF-8'); ?></span> <button onclick="logout()">Salir</button></p>
-            <textarea id="noteInput" placeholder="Escribe una nota..."></textarea>
-            <button onclick="addNote()">📝 Publicar Nota</button>
+            <p>👤 Sesión iniciada como <span id="userDisplay"><?php echo htmlspecialchars($loggedUser ?? '', ENT_QUOTES, 'UTF-8'); ?></span>
+                <a id="manageUsersLink" href="admin_users.php" style="display:none;">Gestionar usuarios</a>
+                <button onclick="logout()">Salir</button></p>
+            <textarea id="noteInput" placeholder="Escribe una nota..." style="display:none;"></textarea>
+            <button id="addNoteBtn" onclick="addNote()" style="display:none;">📝 Publicar Nota</button>
         </div>
 
         <h2>📚 Todas las notas</h2>
@@ -61,6 +64,7 @@ $loggedUser = $_SESSION['username'] ?? null;
 
     <script>
         const loggedUser = <?php echo $loggedUser ? json_encode($loggedUser) : 'null'; ?>;
+        const loggedRole = <?php echo $loggedRole ? (int)$loggedRole : 'null'; ?>;
     </script>
     <script src="script.js"></script>
 </body>

--- a/login.php
+++ b/login.php
@@ -11,14 +11,15 @@ if ($username === '' || $password === '') {
     exit;
 }
 
-$stmt = $pdo->prepare('SELECT id, password FROM users WHERE username = ?');
+$stmt = $pdo->prepare('SELECT id, password, role_id FROM users WHERE username = ?');
 $stmt->execute([$username]);
 $user = $stmt->fetch();
 
 if ($user && password_verify($password, $user['password'])) {
     $_SESSION['user_id'] = $user['id'];
     $_SESSION['username'] = $username;
-    echo json_encode(['success' => true, 'username' => $username]);
+    $_SESSION['role_id'] = (int)$user['role_id'];
+    echo json_encode(['success' => true, 'username' => $username, 'role' => (int)$user['role_id']]);
 } else {
     echo json_encode(['success' => false, 'message' => 'Credenciales incorrectas']);
 }

--- a/script.js
+++ b/script.js
@@ -3,7 +3,11 @@ const registerSection = document.getElementById('registerSection');
 const noteSection = document.getElementById('noteSection');
 const notesList = document.getElementById('notesList');
 const noteInput = document.getElementById('noteInput');
+const addNoteBtn = document.getElementById('addNoteBtn');
+const manageUsersLink = document.getElementById('manageUsersLink');
 const userDisplay = document.getElementById('userDisplay');
+
+let currentRole = typeof loggedRole !== 'undefined' ? loggedRole : null;
 
 // Mostrar u ocultar secciones
 function showRegister() {
@@ -18,13 +22,27 @@ function showLogin() {
 
 // Verifica si hay una sesión iniciada
 window.onload = () => {
-    if (loggedUser) {
+    if (typeof loggedUser !== 'undefined' && loggedUser &&
+        loginSection && noteSection && userDisplay) {
         userDisplay.textContent = loggedUser;
         loginSection.style.display = 'none';
         noteSection.style.display = 'block';
+        applyRolePermissions();
         renderNotes();
     }
 };
+
+function applyRolePermissions() {
+    if (currentRole === 1) {
+        if (noteInput) noteInput.style.display = 'block';
+        if (addNoteBtn) addNoteBtn.style.display = 'inline-block';
+        if (manageUsersLink) manageUsersLink.style.display = 'inline';
+    } else {
+        if (noteInput) noteInput.style.display = 'none';
+        if (addNoteBtn) addNoteBtn.style.display = 'none';
+        if (manageUsersLink) manageUsersLink.style.display = 'none';
+    }
+}
 
 // Registrar usuario
 async function register() {
@@ -63,8 +81,10 @@ async function login() {
     const data = await res.json();
     if (data.success) {
         userDisplay.textContent = data.username;
+        currentRole = data.role;
         loginSection.style.display = 'none';
         noteSection.style.display = 'block';
+        applyRolePermissions();
         renderNotes();
     } else {
         alert('❌ ' + data.message);
@@ -119,34 +139,36 @@ async function renderNotes() {
             ? `<div class="note-meta">🔄 ${note.updated_by} | 🕒 ${note.updated_at}</div>`
             : '';
 
+        const statusSelect = currentRole === 1
+            ? `<select data-note-id="${note.id}">
+                <option value="Pending" ${note.status === 'Pending' ? 'selected' : ''}>Pending</option>
+                <option value="Completed" ${note.status === 'Completed' ? 'selected' : ''}>Completed</option>
+              </select>`
+            : '';
+
         // Genera el HTML
         noteDiv.innerHTML = `
       <div class="note-meta">👤 ${note.username} | 🕒 ${note.created_at}</div>
       <div>${note.content}</div>
       <div class="note-meta">Estado: <strong>${note.status}</strong></div>
-      <select data-note-id="${note.id}">
-        <option value="Pending" ${note.status === 'Pending' ? 'selected' : ''}>Pending</option>
-        <option value="Completed" ${note.status === 'Completed' ? 'selected' : ''}>Completed</option>
-      </select>
+      ${statusSelect}
       ${updatedInfo}
     `;
 
-        // Maneja el cambio de estatus SIN tener que re-renderizar todo
-        const selectEl = noteDiv.querySelector('select');
-        selectEl.addEventListener('change', async (e) => {
-            const newStatus = e.target.value;
-            // Actualiza en el backend
-            await changeStatus(note.id, newStatus);
+        if (currentRole === 1) {
+            const selectEl = noteDiv.querySelector('select');
+            selectEl.addEventListener('change', async (e) => {
+                const newStatus = e.target.value;
+                await changeStatus(note.id, newStatus);
 
-            // Actualiza clases visuales según el nuevo estatus
-            noteDiv.classList.remove('pending', 'completed');
-            const newClass = newStatus.toLowerCase() === 'completed' ? 'completed' : 'pending';
-            noteDiv.classList.add(newClass);
+                noteDiv.classList.remove('pending', 'completed');
+                const newClass = newStatus.toLowerCase() === 'completed' ? 'completed' : 'pending';
+                noteDiv.classList.add(newClass);
 
-            // (Opcional) Actualiza el texto "Estado: ..."
-            const metaEstado = noteDiv.querySelector('.note-meta:nth-of-type(2)');
-            if (metaEstado) metaEstado.innerHTML = `Estado: <strong>${newStatus}</strong>`;
-        });
+                const metaEstado = noteDiv.querySelector('.note-meta:nth-of-type(2)');
+                if (metaEstado) metaEstado.innerHTML = `Estado: <strong>${newStatus}</strong>`;
+            });
+        }
 
         notesList.appendChild(noteDiv);
     });

--- a/update_status.php
+++ b/update_status.php
@@ -8,6 +8,11 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+if (($_SESSION['role_id'] ?? 0) !== 1) {
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+
 $noteId = intval($_POST['id'] ?? 0);
 $status = $_POST['status'] ?? '';
 


### PR DESCRIPTION
## Summary
- Add role information to session and login response
- Restrict note creation and status updates to administrators only
- Hide management UI from receptionists and expose it conditionally based on role

## Testing
- `php -l login.php`
- `php -l add_note.php`
- `php -l update_status.php`
- `php -l index.php`
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68967585e2b08325a74e38fa2bc68a0c