### PR TITLE
Implement role-based access control and improve admin UI

### DIFF
--- a/add_note.php
+++ b/add_note.php
@@ -1,27 +1,39 @@
 <?php
 session_start();
 require 'db.php';
-header('Content-Type: application/json');
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Método no permitido']);
+    exit;
+}
 
 if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
     echo json_encode(['success' => false, 'message' => 'No autenticado']);
     exit;
 }
 
-if (($_SESSION['role_id'] ?? 0) !== 1) {
-    echo json_encode(['success' => false, 'message' => 'No autorizado']);
-    exit;
+// Acepta JSON o FormData
+$ct  = $_SERVER['CONTENT_TYPE'] ?? '';
+$raw = file_get_contents('php://input') ?: '';
+if (stripos($ct, 'application/json') !== false) {
+    $data = json_decode($raw, true) ?: [];
+} else {
+    $data = $_POST;
 }
 
-$content = trim($_POST['content'] ?? '');
+$content = trim($data['content'] ?? '');
 if ($content === '') {
     echo json_encode(['success' => false, 'message' => 'Contenido vacío']);
     exit;
 }
 
-$stmt = $pdo->prepare('INSERT INTO notes (user_id, content, status) VALUES (?, ?, "Pending")');
-$stmt->execute([$_SESSION['user_id'], $content]);
+$stmt = $pdo->prepare('INSERT INTO notes (content, created_by, status, created_at) VALUES (?, ?, "Pending", NOW())');
+$stmt->execute([$content, $_SESSION['user_id']]);
 
-echo json_encode(['success' => true]);
-?>
-
+echo json_encode(['success' => true, 'id' => (int)$pdo->lastInsertId()]);

--- a/add_note.php
+++ b/add_note.php
@@ -8,6 +8,11 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+if (($_SESSION['role_id'] ?? 0) !== 1) {
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+
 $content = trim($_POST['content'] ?? '');
 if ($content === '') {
     echo json_encode(['success' => false, 'message' => 'Contenido vacío']);

--- a/admin_users.php
+++ b/admin_users.php
@@ -29,7 +29,7 @@ if (!$me || (int)$me['role_id'] !== 1) {
     <link href="style.css" rel="stylesheet">
 </head>
 
-<body>
+<body class="users-page">
     <div class="users-container" id="usersApp">
         <header class="users-header">
             <h1>Administrar Usuarios</h1>

--- a/fetch_notes.php
+++ b/fetch_notes.php
@@ -1,16 +1,21 @@
 <?php
 session_start();
+require 'db.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
     echo json_encode(['success' => false, 'message' => 'No autenticado']);
     exit;
 }
 
-require 'db.php';
-header('Content-Type: application/json');
+$sql = 'SELECT n.id, n.content, n.status, n.created_at, u.username
+        FROM notes n
+        JOIN users u ON u.id = n.created_by
+        ORDER BY n.id DESC';
+$notes = $pdo->query($sql)->fetchAll();
 
-$stmt = $pdo->query("SELECT notes.id, notes.content, notes.created_at, notes.status, notes.updated_at, u1.username AS username, u2.username AS updated_by FROM notes JOIN users u1 ON notes.user_id = u1.id LEFT JOIN users u2 ON notes.updated_by = u2.id ORDER BY notes.created_at DESC");
-$notes = $stmt->fetchAll();
-
-echo json_encode($notes);
-?>
+echo json_encode(['success' => true, 'notes' => $notes]);

--- a/index.php
+++ b/index.php
@@ -53,20 +53,23 @@ $loggedRole = $_SESSION['role_id'] ?? null;
         <div id="noteSection" <?php if (!$loggedUser) echo 'style="display:none;"'; ?>>
             <p>👤 Sesión iniciada como <span id="userDisplay"><?php echo htmlspecialchars($loggedUser ?? '', ENT_QUOTES, 'UTF-8'); ?></span>
                 <a id="manageUsersLink" href="admin_users.php" style="display:none;">Gestionar usuarios</a>
-                <button onclick="logout()">Salir</button></p>
+                <button onclick="logout()">Salir</button>
+            </p>
             <textarea id="noteInput" placeholder="Escribe una nota..." style="display:none;"></textarea>
             <button id="addNoteBtn" onclick="addNote()" style="display:none;">📝 Publicar Nota</button>
         </div>
 
-        <h2>📚 Todas las notas</h2>
-        <div id="notesList"></div>
+        <h2 <?= !$loggedUser ? 'style="display:none;"' : '' ?>>📚 Todas las notas</h2>
+        <div id="notesList" <?= !$loggedUser ? 'style="display:none;"' : '' ?>></div>
     </div>
 
     <script>
-        const loggedUser = <?php echo $loggedUser ? json_encode($loggedUser) : 'null'; ?>;
-        const loggedRole = <?php echo $loggedRole ? (int)$loggedRole : 'null'; ?>;
+        const loggedUser = <?php echo json_encode($_SESSION['username'] ?? null); ?>;
+        const loggedRole = <?php echo json_encode($_SESSION['role_id'] ?? null); ?>; // 1=admin, 2=recep
     </script>
-    <script src="script.js"></script>
+    <script src="script.js">
+
+    </script>
 </body>
 
 </html>

--- a/index.php
+++ b/index.php
@@ -20,6 +20,7 @@ require 'db.php';
 // }
 
 $loggedUser = $_SESSION['username'] ?? null;
+$loggedRole = $_SESSION['role_id'] ?? null;
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -50,9 +51,11 @@ $loggedUser = $_SESSION['username'] ?? null;
         </div>
 
         <div id="noteSection" <?php if (!$loggedUser) echo 'style="display:none;"'; ?>>
-            <p>👤 Sesión iniciada como <span id="userDisplay"><?php echo htmlspecialchars($loggedUser ?? '', ENT_QUOTES, 'UTF-8'); ?></span> <button onclick="logout()">Salir</button></p>
-            <textarea id="noteInput" placeholder="Escribe una nota..."></textarea>
-            <button onclick="addNote()">📝 Publicar Nota</button>
+            <p>👤 Sesión iniciada como <span id="userDisplay"><?php echo htmlspecialchars($loggedUser ?? '', ENT_QUOTES, 'UTF-8'); ?></span>
+                <a id="manageUsersLink" href="admin_users.php" style="display:none;">Gestionar usuarios</a>
+                <button onclick="logout()">Salir</button></p>
+            <textarea id="noteInput" placeholder="Escribe una nota..." style="display:none;"></textarea>
+            <button id="addNoteBtn" onclick="addNote()" style="display:none;">📝 Publicar Nota</button>
         </div>
 
         <h2>📚 Todas las notas</h2>
@@ -61,6 +64,7 @@ $loggedUser = $_SESSION['username'] ?? null;
 
     <script>
         const loggedUser = <?php echo $loggedUser ? json_encode($loggedUser) : 'null'; ?>;
+        const loggedRole = <?php echo $loggedRole ? (int)$loggedRole : 'null'; ?>;
     </script>
     <script src="script.js"></script>
 </body>

--- a/login.php
+++ b/login.php
@@ -11,14 +11,15 @@ if ($username === '' || $password === '') {
     exit;
 }
 
-$stmt = $pdo->prepare('SELECT id, password FROM users WHERE username = ?');
+$stmt = $pdo->prepare('SELECT id, password, role_id FROM users WHERE username = ?');
 $stmt->execute([$username]);
 $user = $stmt->fetch();
 
 if ($user && password_verify($password, $user['password'])) {
     $_SESSION['user_id'] = $user['id'];
     $_SESSION['username'] = $username;
-    echo json_encode(['success' => true, 'username' => $username]);
+    $_SESSION['role_id'] = (int)$user['role_id'];
+    echo json_encode(['success' => true, 'username' => $username, 'role' => (int)$user['role_id']]);
 } else {
     echo json_encode(['success' => false, 'message' => 'Credenciales incorrectas']);
 }

--- a/login.php
+++ b/login.php
@@ -16,12 +16,13 @@ $stmt->execute([$username]);
 $user = $stmt->fetch();
 
 if ($user && password_verify($password, $user['password'])) {
-    $_SESSION['user_id'] = $user['id'];
+    session_regenerate_id(true);
+    $_SESSION['user_id'] = (int)$user['id'];
     $_SESSION['username'] = $username;
     $_SESSION['role_id'] = (int)$user['role_id'];
-    echo json_encode(['success' => true, 'username' => $username, 'role' => (int)$user['role_id']]);
+    echo json_encode(['success' => true, 'username' => $username, 'role_id' => (int)$user['role_id']]);
+    exit;
 } else {
     echo json_encode(['success' => false, 'message' => 'Credenciales incorrectas']);
 }
-?>
 

--- a/script.js
+++ b/script.js
@@ -41,16 +41,19 @@ window.onload = () => {
     }
 };
 
+// Reemplaza tu applyRolePermissions() por esta versión
+function canPost() {
+    return currentRole === 1 || currentRole === 2; // admin y recepcionista
+}
+function canManageUsers() {
+    return currentRole === 1; // solo admin
+}
+
 function applyRolePermissions() {
-    if (currentRole === 1) {
-        if (noteInput) noteInput.style.display = 'block';
-        if (addNoteBtn) addNoteBtn.style.display = 'inline-block';
-        if (manageUsersLink) manageUsersLink.style.display = 'inline';
-    } else {
-        if (noteInput) noteInput.style.display = 'none';
-        if (addNoteBtn) addNoteBtn.style.display = 'none';
-        if (manageUsersLink) manageUsersLink.style.display = 'none';
-    }
+    const showPost = canPost();
+    if (noteInput) noteInput.style.display = showPost ? 'block' : 'none';
+    if (addNoteBtn) addNoteBtn.style.display = showPost ? 'inline-block' : 'none';
+    if (manageUsersLink) manageUsersLink.style.display = canManageUsers() ? 'inline' : 'none';
 }
 
 // Registrar usuario
@@ -86,11 +89,11 @@ async function login() {
     fd.append('username', username);
     fd.append('password', password);
 
-    const res = await fetch('login.php', { method: 'POST', body: fd });
+    const res = await fetch('login.php', { method: 'POST', body: fd, credentials: 'include' });
     const data = await res.json();
     if (data.success) {
         userDisplay.textContent = data.username;
-        currentRole = data.role;
+        currentRole = data.role_id;   // <— usa role_id del backend
         loginSection.style.display = 'none';
         noteSection.style.display = 'block';
         applyRolePermissions();
@@ -100,25 +103,23 @@ async function login() {
     }
 }
 
+
 // Logout
 async function logout() {
-    await fetch('logout.php');
+    await fetch('logout.php', { credentials: 'include' });
     location.reload();
 }
+
 
 // Agregar nota
 async function addNote() {
     const content = noteInput.value.trim();
-
-    if (!content) {
-        alert('⚠️ Escribe algo para publicar');
-        return;
-    }
+    if (!content) { alert('⚠️ Escribe algo para publicar'); return; }
 
     const fd = new FormData();
     fd.append('content', content);
 
-    const res = await fetch('add_note.php', { method: 'POST', body: fd });
+    const res = await fetch('add_note.php', { method: 'POST', body: fd, credentials: 'include' });
     const data = await res.json();
     if (data.success) {
         noteInput.value = '';
@@ -128,9 +129,10 @@ async function addNote() {
     }
 }
 
+
 // Mostrar todas las notas
 async function renderNotes() {
-    const res = await fetch('fetch_notes.php');
+    const res = await fetch('fetch_notes.php', { credentials: 'include' });
     const notes = await res.json();
     notesList.innerHTML = '';
 
@@ -187,7 +189,7 @@ async function changeStatus(id, status) {
     const fd = new FormData();
     fd.append('id', id);
     fd.append('status', status);
-    const res = await fetch('update_status.php', { method: 'POST', body: fd });
+    const res = await fetch('update_status.php', { method: 'POST', body: fd, credentials: 'include' });
     const data = await res.json();
     if (data.success) {
         renderNotes();
@@ -195,6 +197,7 @@ async function changeStatus(id, status) {
         alert('⚠️ ' + data.message);
     }
 }
+
 
 // ======= USERS PANEL (append to script.js) =======
 (() => {
@@ -398,3 +401,4 @@ async function changeStatus(id, status) {
     resetForm();
     loadUsers(1);
 })();
+

--- a/script.js
+++ b/script.js
@@ -3,7 +3,20 @@ const registerSection = document.getElementById('registerSection');
 const noteSection = document.getElementById('noteSection');
 const notesList = document.getElementById('notesList');
 const noteInput = document.getElementById('noteInput');
+const addNoteBtn = document.getElementById('addNoteBtn');
+const manageUsersLink = document.getElementById('manageUsersLink');
 const userDisplay = document.getElementById('userDisplay');
+
+let currentRole = typeof loggedRole !== 'undefined' ? loggedRole : null;
+
+function escapeHtml(s) {
+    return String(s ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
 
 // Mostrar u ocultar secciones
 function showRegister() {
@@ -18,13 +31,27 @@ function showLogin() {
 
 // Verifica si hay una sesión iniciada
 window.onload = () => {
-    if (loggedUser) {
+    if (typeof loggedUser !== 'undefined' && loggedUser &&
+        loginSection && noteSection && userDisplay) {
         userDisplay.textContent = loggedUser;
         loginSection.style.display = 'none';
         noteSection.style.display = 'block';
+        applyRolePermissions();
         renderNotes();
     }
 };
+
+function applyRolePermissions() {
+    if (currentRole === 1) {
+        if (noteInput) noteInput.style.display = 'block';
+        if (addNoteBtn) addNoteBtn.style.display = 'inline-block';
+        if (manageUsersLink) manageUsersLink.style.display = 'inline';
+    } else {
+        if (noteInput) noteInput.style.display = 'none';
+        if (addNoteBtn) addNoteBtn.style.display = 'none';
+        if (manageUsersLink) manageUsersLink.style.display = 'none';
+    }
+}
 
 // Registrar usuario
 async function register() {
@@ -63,8 +90,10 @@ async function login() {
     const data = await res.json();
     if (data.success) {
         userDisplay.textContent = data.username;
+        currentRole = data.role;
         loginSection.style.display = 'none';
         noteSection.style.display = 'block';
+        applyRolePermissions();
         renderNotes();
     } else {
         alert('❌ ' + data.message);
@@ -116,53 +145,42 @@ async function renderNotes() {
         noteDiv.classList.add(statusClass);
 
         const updatedInfo = note.updated_by
-            ? `<div class="note-meta">🔄 ${note.updated_by} | 🕒 ${note.updated_at}</div>`
+            ? `<div class="note-meta">🔄 ${escapeHtml(note.updated_by)} | 🕒 ${note.updated_at}</div>`
+            : '';
+
+        const statusSelect = currentRole === 1
+            ? `<select data-note-id="${note.id}">
+                <option value="Pending" ${note.status === 'Pending' ? 'selected' : ''}>Pending</option>
+                <option value="Completed" ${note.status === 'Completed' ? 'selected' : ''}>Completed</option>
+              </select>`
             : '';
 
         // Genera el HTML
         noteDiv.innerHTML = `
-      <div class="note-meta">👤 ${note.username} | 🕒 ${note.created_at}</div>
-      <div>${note.content}</div>
+      <div class="note-meta">👤 ${escapeHtml(note.username)} | 🕒 ${note.created_at}</div>
+      <div>${escapeHtml(note.content)}</div>
       <div class="note-meta">Estado: <strong>${note.status}</strong></div>
-      <select data-note-id="${note.id}">
-        <option value="Pending" ${note.status === 'Pending' ? 'selected' : ''}>Pending</option>
-        <option value="Completed" ${note.status === 'Completed' ? 'selected' : ''}>Completed</option>
-      </select>
+      ${statusSelect}
       ${updatedInfo}
     `;
 
-        // Maneja el cambio de estatus SIN tener que re-renderizar todo
-        const selectEl = noteDiv.querySelector('select');
-        selectEl.addEventListener('change', async (e) => {
-            const newStatus = e.target.value;
-            // Actualiza en el backend
-            await changeStatus(note.id, newStatus);
+        if (currentRole === 1) {
+            const selectEl = noteDiv.querySelector('select');
+            selectEl.addEventListener('change', async (e) => {
+                const newStatus = e.target.value;
+                await changeStatus(note.id, newStatus);
 
-            // Actualiza clases visuales según el nuevo estatus
-            noteDiv.classList.remove('pending', 'completed');
-            const newClass = newStatus.toLowerCase() === 'completed' ? 'completed' : 'pending';
-            noteDiv.classList.add(newClass);
+                noteDiv.classList.remove('pending', 'completed');
+                const newClass = newStatus.toLowerCase() === 'completed' ? 'completed' : 'pending';
+                noteDiv.classList.add(newClass);
 
-            // (Opcional) Actualiza el texto "Estado: ..."
-            const metaEstado = noteDiv.querySelector('.note-meta:nth-of-type(2)');
-            if (metaEstado) metaEstado.innerHTML = `Estado: <strong>${newStatus}</strong>`;
-        });
+                const metaEstado = noteDiv.querySelector('.note-meta:nth-of-type(2)');
+                if (metaEstado) metaEstado.innerHTML = `Estado: <strong>${newStatus}</strong>`;
+            });
+        }
 
         notesList.appendChild(noteDiv);
     });
-}
-
-/* Ejemplo de changeStatus: ajusta a tu endpoint */
-async function changeStatus(id, status) {
-    // Devuelve promesa para poder await en el listener
-    const res = await fetch('update_status.php', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ id, status })
-    });
-    if (!res.ok) {
-        console.error('No se pudo actualizar el estatus');
-    }
 }
 
 async function changeStatus(id, status) {
@@ -232,15 +250,6 @@ async function changeStatus(id, status) {
         </td>
       </tr>
     `).join('');
-    }
-
-    function escapeHtml(s) {
-        return String(s ?? '')
-            .replaceAll('&', '&amp;')
-            .replaceAll('<', '&lt;')
-            .replaceAll('>', '&gt;')
-            .replaceAll('"', '&quot;')
-            .replaceAll("'", '&#39;');
     }
 
     async function loadUsers(page = 1) {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /* General */
 body {
     font-family: 'Segoe UI', sans-serif;
-    background-color: #f0f2f5;
+    background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
     margin: 0;
     padding: 20px;
     display: flex;
@@ -160,18 +160,17 @@ a:hover {
 /* ======= USERS PANEL (append to style.css) ======= */
 
 :root {
-    --users-bg: #0f172a;
-    /* fondo oscuro (combínalo con tu sitio) */
-    --users-card: #111827;
-    --users-border: #1f2937;
-    --users-text: #e5e7eb;
-    --users-muted: #9ca3af;
+    --users-bg: #f9fafb;
+    --users-card: #ffffff;
+    --users-border: #d1d5db;
+    --users-text: #1f2937;
+    --users-muted: #6b7280;
     --users-primary: #3b82f6;
     --users-danger: #ef4444;
     --users-ok: #10b981;
 }
 
-body {
+.users-page {
     background: var(--users-bg);
     color: var(--users-text);
 }
@@ -239,7 +238,7 @@ body {
     padding: 10px 12px;
     border-radius: 8px;
     border: 1px solid var(--users-border);
-    background: #0b1220;
+    background: var(--users-card);
     color: var(--users-text);
 }
 
@@ -258,14 +257,14 @@ body {
 .users-btn {
     padding: 8px 12px;
     border: 1px solid var(--users-border);
-    background: #0b1220;
+    background: var(--users-card);
     color: var(--users-text);
     border-radius: 8px;
     cursor: pointer;
 }
 
 .users-btn:hover {
-    border-color: #334155;
+    border-color: var(--users-primary);
 }
 
 .users-btn.primary {
@@ -326,7 +325,7 @@ body {
     padding: 8px 12px;
     border-radius: 8px;
     border: 1px solid var(--users-border);
-    background: #0b1220;
+    background: var(--users-card);
     color: var(--users-text);
     min-width: 220px;
 }
@@ -351,13 +350,17 @@ body {
 }
 
 .users-table th {
-    background: #0c1425;
+    background: #f3f4f6;
     font-weight: 700;
 }
 
 .users-table td.empty {
     text-align: center;
     color: var(--users-muted);
+}
+
+.users-table tr:nth-child(even) {
+    background: #f9fafb;
 }
 
 .col-actions {

--- a/style.css
+++ b/style.css
@@ -82,12 +82,12 @@ button:hover {
 
 /* Colores por estatus */
 .note.pending {
-    background-color: #fffde7;
+    background-color: #fff7a1;
     /* amarillo pastel claro */
 }
 
 .note.completed {
-    background-color: #e8f5e9;
+    background-color: #8afa93;
     /* verde pastel claro */
 }
 

--- a/update_status.php
+++ b/update_status.php
@@ -8,7 +8,11 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
-if (($_SESSION['role_id'] ?? 0) !== 1) {
+// Verificación de rol admin (role_id = 1)
+$me = $pdo->prepare('SELECT role_id FROM users WHERE id = ?');
+$me->execute([$_SESSION['user_id']]);
+if ((int)$me->fetchColumn() !== 1) {
+    http_response_code(403);
     echo json_encode(['success' => false, 'message' => 'No autorizado']);
     exit;
 }
@@ -25,4 +29,3 @@ $stmt = $pdo->prepare('UPDATE notes SET status = ?, updated_by = ?, updated_at =
 $stmt->execute([$status, $_SESSION['user_id'], $noteId]);
 
 echo json_encode(['success' => true]);
-?>

--- a/update_status.php
+++ b/update_status.php
@@ -8,6 +8,11 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+if (($_SESSION['role_id'] ?? 0) !== 1) {
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+
 $noteId = intval($_POST['id'] ?? 0);
 $status = $_POST['status'] ?? '';
 

--- a/users.php
+++ b/users.php
@@ -60,7 +60,7 @@ try {
             // GET /users.php           -> lista
             // GET /users.php?id=3      -> detalle
             if ($id) {
-                $stmt = $pdo->prepare("SELECT id, username, role_id, created_at FROM users WHERE id = ?");
+                $stmt = $pdo->prepare("SELECT id, username, role_id FROM users WHERE id = ?");
                 $stmt->execute([$id]);
                 $row = $stmt->fetch();
                 if (!$row) jsonResponse(['success' => false, 'message' => 'Usuario no encontrado'], 404);
@@ -71,7 +71,7 @@ try {
                 $offset = ($page - 1) * $limit;
 
                 $total = (int)$pdo->query("SELECT COUNT(*) FROM users")->fetchColumn();
-                $stmt  = $pdo->prepare("SELECT id, username, role_id, created_at
+                $stmt  = $pdo->prepare("SELECT id, username, role_id
                                         FROM users
                                         ORDER BY id DESC
                                         LIMIT :limit OFFSET :offset");


### PR DESCRIPTION
## Summary
- Add role information to session and login response to enable role-based permissions
- Restrict note creation and status updates to administrators only while hiding management UI for receptionists
- Sanitize note rendering, streamline status updates and fix admin user listing; refresh styles with a cleaner look

## Testing
- `php -l admin_users.php`
- `php -l users.php`
- `php -l index.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68967585e2b08325a74e38fa2bc68a0c