### PR TITLE
feat: allow admins to edit and delete notes

### DIFF
--- a/add_note.php
+++ b/add_note.php
@@ -33,7 +33,7 @@ if ($content === '') {
     exit;
 }
 
-$stmt = $pdo->prepare('INSERT INTO notes (content, created_by, status, created_at) VALUES (?, ?, "Pending", NOW())');
-$stmt->execute([$content, $_SESSION['user_id']]);
+$stmt = $pdo->prepare('INSERT INTO notes (user_id, content, status, created_at) VALUES (?, ?, "Pending", NOW())');
+$stmt->execute([$_SESSION['user_id'], $content]);
 
 echo json_encode(['success' => true, 'id' => (int)$pdo->lastInsertId()]);

--- a/delete_note.php
+++ b/delete_note.php
@@ -1,0 +1,36 @@
+<?php
+session_start();
+require 'db.php';
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Método no permitido']);
+    exit;
+}
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'No autenticado']);
+    exit;
+}
+
+$me = $pdo->prepare('SELECT role_id FROM users WHERE id = ?');
+$me->execute([$_SESSION['user_id']]);
+if ((int)$me->fetchColumn() !== 1) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+
+$id = intval($_POST['id'] ?? 0);
+if (!$id) {
+    echo json_encode(['success' => false, 'message' => 'ID inválido']);
+    exit;
+}
+
+$stmt = $pdo->prepare('DELETE FROM notes WHERE id = ?');
+$stmt->execute([$id]);
+
+echo json_encode(['success' => true]);
+?>

--- a/edit_note.php
+++ b/edit_note.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+require 'db.php';
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Método no permitido']);
+    exit;
+}
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'No autenticado']);
+    exit;
+}
+
+$me = $pdo->prepare('SELECT role_id FROM users WHERE id = ?');
+$me->execute([$_SESSION['user_id']]);
+if ((int)$me->fetchColumn() !== 1) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'No autorizado']);
+    exit;
+}
+
+$id = intval($_POST['id'] ?? 0);
+$content = trim($_POST['content'] ?? '');
+if (!$id || $content === '') {
+    echo json_encode(['success' => false, 'message' => 'Datos inválidos']);
+    exit;
+}
+
+$stmt = $pdo->prepare('UPDATE notes SET content = ?, updated_by = ?, updated_at = NOW() WHERE id = ?');
+$stmt->execute([$content, $_SESSION['user_id'], $id]);
+
+echo json_encode(['success' => true]);
+?>

--- a/fetch_notes.php
+++ b/fetch_notes.php
@@ -12,9 +12,16 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
-$sql = 'SELECT n.id, n.content, n.status, n.created_at, u.username
+$sql = 'SELECT n.id,
+               n.content,
+               n.status,
+               n.created_at,
+               u.username,
+               u2.username AS updated_by,
+               n.updated_at
         FROM notes n
-        JOIN users u ON u.id = n.created_by
+        JOIN users u ON u.id = n.user_id
+        LEFT JOIN users u2 ON u2.id = n.updated_by
         ORDER BY n.id DESC';
 $notes = $pdo->query($sql)->fetchAll();
 

--- a/script.js
+++ b/script.js
@@ -133,7 +133,8 @@ async function addNote() {
 // Mostrar todas las notas
 async function renderNotes() {
     const res = await fetch('fetch_notes.php', { credentials: 'include' });
-    const notes = await res.json();
+    const data = await res.json();
+    const notes = data.notes || [];
     notesList.innerHTML = '';
 
     notes.forEach(note => {
@@ -157,6 +158,13 @@ async function renderNotes() {
               </select>`
             : '';
 
+        const adminButtons = currentRole === 1
+            ? `<div class="note-actions">
+                <button data-edit="${note.id}">✏️</button>
+                <button data-delete="${note.id}">🗑️</button>
+              </div>`
+            : '';
+
         // Genera el HTML
         noteDiv.innerHTML = `
       <div class="note-meta">👤 ${escapeHtml(note.username)} | 🕒 ${note.created_at}</div>
@@ -164,21 +172,33 @@ async function renderNotes() {
       <div class="note-meta">Estado: <strong>${note.status}</strong></div>
       ${statusSelect}
       ${updatedInfo}
+      ${adminButtons}
     `;
 
         if (currentRole === 1) {
             const selectEl = noteDiv.querySelector('select');
-            selectEl.addEventListener('change', async (e) => {
-                const newStatus = e.target.value;
-                await changeStatus(note.id, newStatus);
+            if (selectEl) {
+                selectEl.addEventListener('change', async (e) => {
+                    const newStatus = e.target.value;
+                    await changeStatus(note.id, newStatus);
 
-                noteDiv.classList.remove('pending', 'completed');
-                const newClass = newStatus.toLowerCase() === 'completed' ? 'completed' : 'pending';
-                noteDiv.classList.add(newClass);
+                    noteDiv.classList.remove('pending', 'completed');
+                    const newClass = newStatus.toLowerCase() === 'completed' ? 'completed' : 'pending';
+                    noteDiv.classList.add(newClass);
 
-                const metaEstado = noteDiv.querySelector('.note-meta:nth-of-type(2)');
-                if (metaEstado) metaEstado.innerHTML = `Estado: <strong>${newStatus}</strong>`;
-            });
+                    const metaEstado = noteDiv.querySelector('.note-meta:nth-of-type(2)');
+                    if (metaEstado) metaEstado.innerHTML = `Estado: <strong>${newStatus}</strong>`;
+                });
+            }
+
+            const editBtn = noteDiv.querySelector('[data-edit]');
+            const delBtn = noteDiv.querySelector('[data-delete]');
+            if (editBtn) {
+                editBtn.addEventListener('click', () => editNote(note.id, note.content));
+            }
+            if (delBtn) {
+                delBtn.addEventListener('click', () => deleteNote(note.id));
+            }
         }
 
         notesList.appendChild(noteDiv);
@@ -190,6 +210,34 @@ async function changeStatus(id, status) {
     fd.append('id', id);
     fd.append('status', status);
     const res = await fetch('update_status.php', { method: 'POST', body: fd, credentials: 'include' });
+    const data = await res.json();
+    if (data.success) {
+        renderNotes();
+    } else {
+        alert('⚠️ ' + data.message);
+    }
+}
+
+async function editNote(id, currentContent) {
+    const newContent = prompt('Editar nota:', currentContent);
+    if (newContent === null) return;
+    const fd = new FormData();
+    fd.append('id', id);
+    fd.append('content', newContent.trim());
+    const res = await fetch('edit_note.php', { method: 'POST', body: fd, credentials: 'include' });
+    const data = await res.json();
+    if (data.success) {
+        renderNotes();
+    } else {
+        alert('⚠️ ' + data.message);
+    }
+}
+
+async function deleteNote(id) {
+    if (!confirm('¿Eliminar nota?')) return;
+    const fd = new FormData();
+    fd.append('id', id);
+    const res = await fetch('delete_note.php', { method: 'POST', body: fd, credentials: 'include' });
     const data = await res.json();
     if (data.success) {
         renderNotes();

--- a/style.css
+++ b/style.css
@@ -102,6 +102,13 @@ button:hover {
     margin-top: 8px;
 }
 
+.note-actions button {
+    width: auto;
+    padding: 4px 8px;
+    margin-top: 8px;
+    margin-right: 4px;
+}
+
 .note-meta {
     font-size: 13px;
     color: #555;


### PR DESCRIPTION
## Summary
- fix note creation to use `user_id`
- expose `updated_by` info and support admin-only note editing and deletion
- style action buttons for notes

## Testing
- `php -l add_note.php`
- `php -l fetch_notes.php`
- `php -l edit_note.php`
- `php -l delete_note.php`
- `php -l update_status.php`


------
https://chatgpt.com/codex/tasks/task_e_68968f359e7883258c60088dd59e96df